### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 ## v0.2.0
 
 **BREAKING CHANGE**

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ You can also use dynamic values from the datastore. See the
 
 Remote actions require no configuration. You simply need to specify server to
 run the action on when running the action (same as with other remote actions).
+
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`

--- a/actions/cert_clean.yaml
+++ b/actions/cert_clean.yaml
@@ -1,6 +1,6 @@
 ---
 name: cert_clean
-runner_type: run-python
+runner_type: python-script
 description: Revoke a host's certificate (if applicable) and remove all files related
   to that host from puppet cert's storage.
 enabled: true

--- a/actions/cert_revoke.yaml
+++ b/actions/cert_revoke.yaml
@@ -1,6 +1,6 @@
 ---
 name: cert_revoke
-runner_type: run-python
+runner_type: python-script
 description: Revoke the certificate of a client.
 enabled: true
 entry_point: cert_revoke.py

--- a/actions/cert_sign.yaml
+++ b/actions/cert_sign.yaml
@@ -1,6 +1,6 @@
 ---
 name: cert_sign
-runner_type: run-python
+runner_type: python-script
 description: Sign an outstanding certificate request.
 enabled: true
 entry_point: cert_sign.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - puppet
   - cfg management
   - configuration management
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.